### PR TITLE
Add device tree nodes for lsm6dsl IMU for V5 MPU

### DIFF
--- a/arch/arm64/boot/dts/luci/luci-imx8mq-som.dts
+++ b/arch/arm64/boot/dts/luci/luci-imx8mq-som.dts
@@ -208,6 +208,12 @@
 			>;
 		};
 
+		pinctrl_lsm6dsl: lsm6dsl {
+			fsl,pins = <
+				MX8MQ_IOMUXC_NAND_CLE_GPIO3_IO5 0x00
+			>;
+		};
+
 		pinctrl_i2c2: i2c2grp {
 			fsl,pins = <
 				MX8MQ_IOMUXC_I2C2_SCL_I2C2_SCL	0x4000007f
@@ -385,10 +391,19 @@
 };
 
 &i2c1 {
-	clock-frequency = <100000>;
+	clock-frequency = <400000>;
 	pinctrl-names = "default";
 	pinctrl-0 = <&pinctrl_i2c1>;
-	status = "disabled";
+	status = "okay";
+
+	imu@6a {
+		compatible = "st,lsm6dsl";
+		reg = <0x6a>;
+		interrupt-parent = <&gpio3>;
+		interrupts = <5 IRQ_TYPE_EDGE_RISING>;
+		pinctrl-names = "default";
+		pinctrl-0 = <&pinctrl_lsm6dsl>;
+	};
 };
 
 &i2c2 {


### PR DESCRIPTION
# Changes and reason

Enables the I2C1 bus on the i.MX processor and adds the lsm6dsl IMU to the bus. This IMU is present on the V5 MPU. The IMU is connected to an LIS2MDL magnetometer which is also enabled by these changes.

# High Level Documentation Links
See V5 MPU schematic in https://mfg.duro.app/component/view/64b031a6cd1b080008a4ef7a

# Applicable Requirements

PRS.6.3.9.1 Wheelchair Base/Chassis Pitch
PRS.6.3.9.2 Wheelchair Base/Chassis Roll
PRS.6.3.0.3 Wheelchair Base/Chassis Roll
PRS.6.3.11 System Heading Determination
PRS.6.3.12 System Linear Velocity Determination
PRS.6.3.13 System Angular Velocity Determination
PRS.6.3.14 System Linear Acceleration Determination
PRS.6.3.15 System Angular Acceleration Determination

# Related / Fixed Issues

https://patroness.atlassian.net/browse/L2-4126
https://patroness.atlassian.net/browse/L2-4137

# Risk Control

No changes to risk. This is just enabling the IMU in the kernel. Using the IMU will reduce risk of sensor errors and inaccurate data from the existing IMU.

# Testing Completed

Tested on a V5 MPU and data can be read from the IMU using sysfs. dmesg did not report any errors connecting to the IMU.

Tested on a V4 MPU and the system still boots up just fine with just this error in dmesg: st_lsm6dsx_i2c 0-006a: failed to read whoami register

The V4 MPU shows the IMU in the sysfs but the iio devices are not present.

# Changes to SOUP

None