### PR TITLE
Disable busfreq frequency scaling

### DIFF
--- a/arch/arm64/boot/dts/luci/luci-imx8mq-som.dts
+++ b/arch/arm64/boot/dts/luci/luci-imx8mq-som.dts
@@ -705,3 +705,9 @@
 &snvs_rtc {
 	status = "disabled";
 };
+
+&{/busfreq} {
+	// Disable busfreq since the driver keeps changing the memory frequency which is causing 
+	// performance issues for LUCI.
+	status = "disabled";
+};


### PR DESCRIPTION
This was causing performance issues on LUCI when the ddrc frequency scaled down. This wasn't previously an issue because a driver (maybe wifi/SDIO) was keeping it in high performance mode often enough. When we moved to the Quickdraw board that driver is not installed and serious performance issues were occurring.