### PR TITLE
Device tree fixes

### DIFF
--- a/arch/arm64/boot/dts/luci/luci-imx8mq-som.dts
+++ b/arch/arm64/boot/dts/luci/luci-imx8mq-som.dts
@@ -208,6 +208,12 @@
 			>;
 		};
 
+		pinctrl_lsm6dsl: lsm6dsl {
+			fsl,pins = <
+				MX8MQ_IOMUXC_NAND_CLE_GPIO3_IO5 0x00
+			>;
+		};
+
 		pinctrl_i2c2: i2c2grp {
 			fsl,pins = <
 				MX8MQ_IOMUXC_I2C2_SCL_I2C2_SCL	0x4000007f
@@ -385,10 +391,19 @@
 };
 
 &i2c1 {
-	clock-frequency = <100000>;
+	clock-frequency = <400000>;
 	pinctrl-names = "default";
 	pinctrl-0 = <&pinctrl_i2c1>;
-	status = "disabled";
+	status = "okay";
+
+	imu@6a {
+		compatible = "st,lsm6dsl";
+		reg = <0x6a>;
+		interrupt-parent = <&gpio3>;
+		interrupts = <5 IRQ_TYPE_EDGE_RISING>;
+		pinctrl-names = "default";
+		pinctrl-0 = <&pinctrl_lsm6dsl>;
+	};
 };
 
 &i2c2 {

--- a/arch/arm64/boot/dts/luci/luci-imx8mq-som.dts
+++ b/arch/arm64/boot/dts/luci/luci-imx8mq-som.dts
@@ -652,3 +652,9 @@
 &snvs_rtc {
 	status = "disabled";
 };
+
+&{/busfreq} {
+	// Disable busfreq since the driver keeps changing the memory frequency which is causing 
+	// performance issues for LUCI.
+	status = "disabled";
+};

--- a/arch/arm64/boot/dts/luci/luci-imx8mq-som.dts
+++ b/arch/arm64/boot/dts/luci/luci-imx8mq-som.dts
@@ -590,8 +590,8 @@
 	pinctrl-names = "default";
 	pinctrl-0 = <&pinctrl_sai2>;
 	assigned-clocks = <&clk IMX8MQ_CLK_SAI2>;
-	assigned-clock-parents = <&clk IMX8MQ_AUDIO_PLL1_OUT>;
-	assigned-clock-rates = <49152000>;
+	assigned-clock-parents = <&clk IMX8MQ_AUDIO_PLL2_OUT>;
+	assigned-clock-rates = <45158400>;
 	fsl,sai-asynchronous;
 	status = "okay";
 };


### PR DESCRIPTION
- Adds the IMU for V5 MPU back
- Changes the audio PLL to fix a kernel error about invalid frequencies
- Disables the busfreq scaler. We always need to run at full speed.

This builds and boots on the V5 SOM.