### PR TITLE
Luci 1444 slow imu probe

### DIFF
--- a/arch/arm64/boot/dts/luci/luci-imx8mq-som.dts
+++ b/arch/arm64/boot/dts/luci/luci-imx8mq-som.dts
@@ -399,6 +399,7 @@
 	imu@6a {
 		compatible = "st,lsm6dsl";
 		reg = <0x6a>;
+		st,disable-sensor-hub;  /* Disable magnetometer probing - IMU only */
 		interrupt-parent = <&gpio3>;
 		interrupts = <5 IRQ_TYPE_EDGE_RISING>;
 		pinctrl-names = "default";

--- a/drivers/iio/imu/st_lsm6dsx/st_lsm6dsx_core.c
+++ b/drivers/iio/imu/st_lsm6dsx/st_lsm6dsx_core.c
@@ -2272,10 +2272,14 @@ static int st_lsm6dsx_reset_device(struct st_lsm6dsx_hw *hw)
 	 * possible races on interrupt line 1. If the first interrupt
 	 * line is asserted during hw reset the device will work in
 	 * I3C-only mode (if it is supported)
+	 *
+	 * Skip flush during probe when FIFO is not yet enabled
 	 */
-	err = st_lsm6dsx_flush_fifo(hw);
-	if (err < 0 && err != -ENOTSUPP)
-		return err;
+	if (hw->fifo_mask) {
+		err = st_lsm6dsx_flush_fifo(hw);
+		if (err < 0 && err != -ENOTSUPP)
+			return err;
+	}
 
 	/* device sw reset */
 	reg = &hw->settings->reset;
@@ -2284,7 +2288,8 @@ static int st_lsm6dsx_reset_device(struct st_lsm6dsx_hw *hw)
 	if (err < 0)
 		return err;
 
-	msleep(50);
+	/* AN5040: SW reset completes in 50µs, use 500-1000us for safety margin */
+	usleep_range(500, 1000);
 
 	/* reload trimming parameter */
 	reg = &hw->settings->boot;
@@ -2293,7 +2298,8 @@ static int st_lsm6dsx_reset_device(struct st_lsm6dsx_hw *hw)
 	if (err < 0)
 		return err;
 
-	msleep(50);
+	/* AN5040: Boot procedure completes in 15ms, use ~18ms for safety margin */
+	usleep_range(18000, 20000);
 
 	return 0;
 }
@@ -2620,7 +2626,8 @@ static int st_lsm6dsx_init_regulators(struct device *dev)
 	if (err)
 		return dev_err_probe(dev, err, "failed to enable regulators\n");
 
-	msleep(50);
+	// LUCI does not have separate regulators for this. No need to sleep
+	// msleep(50);
 
 	return 0;
 }


### PR DESCRIPTION
Speeds up the IMU probing with the following changes:
- Disables delays when enabling regulators since we don't have a dedicated regulator for the IMU
- Disables probing the sensor hub. This disables the magnetometer but the magnetometer is unused at the moment.
- Tightened up timing on some of the delays that were way too conservative.

The IMU now initializes in less than 200ms instead of over 2 seconds.

Tested that the IMU displays data in the sys/bus iio subsystem on the gyro and accelerometer channels. The magnetometer is no longer present.